### PR TITLE
Fix type annotation errors in PR.

### DIFF
--- a/src/fair_async_rlock/anyio_fair_async_rlock.py
+++ b/src/fair_async_rlock/anyio_fair_async_rlock.py
@@ -1,5 +1,4 @@
-import asyncio
-from typing import TypeVar, Type
+from typing import TypeVar
 
 import anyio
 
@@ -20,8 +19,8 @@ class AnyIOFairAsyncRLock(BaseFairAsyncRLock[anyio.TaskInfo, anyio.Event]):
     def _get_current_task(self) -> anyio.TaskInfo:
         return anyio.get_current_task()
 
-    def _get_cancelled_exc_class(self) -> Type[BaseException]:
+    def _get_cancelled_exc_class(self) -> type[BaseException]:
         return anyio.get_cancelled_exc_class()
 
-    def _get_wake_event(self) -> asyncio.Event:
+    def _get_wake_event(self) -> anyio.Event:
         return anyio.Event()

--- a/src/fair_async_rlock/asyncio_fair_async_rlock.py
+++ b/src/fair_async_rlock/asyncio_fair_async_rlock.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import TypeVar, Type
+from typing import Any, TypeVar
 
 from fair_async_rlock.base_fair_async_rlock import BaseFairAsyncRLock
 
@@ -10,15 +10,15 @@ TaskType = TypeVar('TaskType')
 EventType = TypeVar('EventType')
 
 
-class FairAsyncRLock(BaseFairAsyncRLock[asyncio.Task, asyncio.Event]):
+class FairAsyncRLock(BaseFairAsyncRLock[asyncio.Task[Any], asyncio.Event]):
     """
     A fair reentrant lock for async programming. Fair means that it respects the order of acquisition.
     """
 
-    def _get_current_task(self) -> asyncio.Task:
+    def _get_current_task(self) -> asyncio.Task[Any] | None:
         return asyncio.current_task()
 
-    def _get_cancelled_exc_class(self) -> Type:
+    def _get_cancelled_exc_class(self) -> type[BaseException]:
         return asyncio.CancelledError
 
     def _get_wake_event(self) -> asyncio.Event:

--- a/src/fair_async_rlock/base_fair_async_rlock.py
+++ b/src/fair_async_rlock/base_fair_async_rlock.py
@@ -1,19 +1,24 @@
 from abc import ABC, abstractmethod
 from collections import deque
 
-from typing import Generic, TypeVar, Type
+from typing import Any, Generic, TypeVar, Protocol
 
-TaskType = TypeVar('TaskType')
-EventType = TypeVar('EventType')
+class _Event(Protocol):
+    def set(self) -> None: ...
+    async def wait(self) -> Any: ...
+
+
+TaskType = TypeVar("TaskType")
+EventType = TypeVar("EventType", bound=_Event)
 
 
 class AbstractFairAsyncRLock(ABC, Generic[TaskType, EventType]):
     @abstractmethod
-    def _get_current_task(self) -> TaskType:
+    def _get_current_task(self) -> TaskType | None:
         ...
 
     @abstractmethod
-    def _get_cancelled_exc_class(self) -> Type[BaseException]:
+    def _get_cancelled_exc_class(self) -> type[BaseException]:
         ...
 
     @abstractmethod


### PR DESCRIPTION
* Add `py.typed` file to get rid of type checker warnings.
* Add/fix some return types to get rid of type checker warnings.